### PR TITLE
nativeOpen() fix in case of connect() fails

### DIFF
--- a/com/etsy/net/UnixDomainSocket.c
+++ b/com/etsy/net/UnixDomainSocket.c
@@ -137,8 +137,12 @@ Java_com_etsy_net_UnixDomainSocket_nativeOpen(JNIEnv * jEnv,
 
     s = socket(PF_UNIX, SOCK_TYPE(jSocketType), 0);
     ASSERTNOERR(s == -1, "nativeOpen: socket");
-    ASSERTNOERR(connect(s, (struct sockaddr *)&sa, salen) == -1,
-            "nativeOpen: connect");
+    if (connect(s, (struct sockaddr *)&sa, salen) == -1) {
+	perror("nativeOpen: connect");
+	int close = close(s);
+	ASSERTNOERR(close == -1, "nativeOpen: close connect error socket");
+	return -1;
+    }
 
     (*jEnv)->ReleaseStringUTFChars(jEnv, jSocketFile, socketFile);
 


### PR DESCRIPTION
Change to nativeOpen() in order to close a recently created socket if the call to connect() fails. This way the socket is closed and can be guaranteed that the operating system will not run out of file descriptors. The modification can be written in a more "nice" way maybe, but it works great in our project.
