### PR TITLE
Proposed changes to address issue #28

### DIFF
--- a/com/etsy/net/JUDS.java
+++ b/com/etsy/net/JUDS.java
@@ -13,14 +13,14 @@ public class JUDS {
     /**
      * A constant for the datagram socket type (connectionless).
      */
-    public static final int SOCK_DGRAM = 0;
+    public static final int SOCK_DGRAM; 
 
     /**
      * A constant for the stream oriented stream socket type (connection-based)
      */
-    public static final int SOCK_STREAM = 1;
+    public static final int SOCK_STREAM; 
+    public static final int SOCK_SEQPACKET; 
 
-    
     public static final int SERVER = 0;
     public static final int CLIENT = 1;
 
@@ -60,6 +60,11 @@ public class JUDS {
             }
             jarURL = prepared;
         }
+        
+        UnixDomainSocket.staticInit();
+        SOCK_DGRAM = UnixDomainSocket.nativeGetSocketType("SOCK_DGRAM");
+        SOCK_STREAM = UnixDomainSocket.nativeGetSocketType("SOCK_STREAM");
+        SOCK_SEQPACKET = UnixDomainSocket.nativeGetSocketType("SOCK_SEQPACKET");
     }
 
     private static ClassLoader judsCl = new URLClassLoader(

--- a/com/etsy/net/UnixDomainSocket.java
+++ b/com/etsy/net/UnixDomainSocket.java
@@ -30,6 +30,10 @@ public abstract class UnixDomainSocket {
 
     private static File jarFile;
     static {
+        staticInit();
+    }
+
+    static void staticInit(){
         // Load the Unix domain socket C library
         getJarPath();
         try {
@@ -208,6 +212,8 @@ public abstract class UnixDomainSocket {
     protected native static int nativeCloseOutput(int nativeSocketFileHandle);
 
     protected native static int nativeUnlink(String socketFile);
+
+    protected native static int nativeGetSocketType(String socketType);
 
     protected UnixDomainSocket()
     {


### PR DESCRIPTION
Use the native enumerations for the socket type.    Detect the enumerations at static initialization with a new JNI function.   Add enumeration for SOCK_SEQPACKET.  This will allow any enumeration to be passed in by users and adds direct  SOCK_SEQPACKET support.   